### PR TITLE
Stop overwriting exports

### DIFF
--- a/django_js_reverse/templates/django_js_reverse/urls_js.tpl
+++ b/django_js_reverse/templates/django_js_reverse/urls_js.tpl
@@ -1,7 +1,4 @@
-var {{ js_var_name }}, exports;
-exports = this;
-
-exports.{{ js_var_name }} = (function () {
+this.{{ js_var_name }} = (function () {
 
     function Urls() {}
 
@@ -44,6 +41,6 @@ exports.{{ js_var_name }} = (function () {
     return Urls;
 })();
 
-exports.{{ js_var_name }}.init();
+this.{{ js_var_name }}.init();
 
 


### PR DESCRIPTION
The script did an export = this, causing any existing export to be overwritten. Loading the script first fixed that, but with RequireJS that isn't an option.
This fix makes it work with RequireJS & Backbone.
