### PR TITLE
Support for URLs from django REST framework

### DIFF
--- a/django_js_reverse/views.py
+++ b/django_js_reverse/views.py
@@ -21,6 +21,7 @@ def urls_js(request):
     url_patterns = list(urlresolvers.get_resolver(None).reverse_dict.items())
     url_list = [(url_name, url_pattern[0][0]) for url_name, url_pattern in url_patterns if
                 (isinstance(url_name, str) or isinstance(url_name, text_type))]
+    url_list = [(("REST_%s" % url_name.replace("-","_"), url_pattern) if '-' in url_name else (url_name, url_pattern)) for url_name, url_pattern in url_list]
 
     return render_to_response('django_js_reverse/urls_js.tpl',
                               {


### PR DESCRIPTION
The default routes created by django-rest-framework contain hyphens
in the url names which don't play well when put into javascript. I have
created a quick hack which replaces hyphons with underscores and
prefixes all url names with "REST_" to avoid collisions.
