### PR TITLE
fixed content type of the jsreverse script

### DIFF
--- a/django_js_reverse/tests/unit_tests.py
+++ b/django_js_reverse/tests/unit_tests.py
@@ -63,6 +63,10 @@ class JSReverseViewTestCase(TestCase):
         self.assertContains(response, "'ns2:test_two_url_args', "
                                       "['ns2/test_two_url_args/%(arg_one)s\\u002D%(arg_two)s/', ['arg_one','arg_two']]")
 
+    def test_content_type(self):
+        response = self.client.post('/jsreverse/')
+        self.assertEqual(response['Content-Type'], 'application/javascript')
+
 
 if __name__ == '__main__':
     sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', '..') + os.sep)

--- a/django_js_reverse/views.py
+++ b/django_js_reverse/views.py
@@ -54,7 +54,7 @@ def urls_js(request):
 
     view_kwargs = {
         'context_instance': RequestContext(request),
-        content_type_keyword_name: content_type_keyword_name
+        content_type_keyword_name: 'application/javascript'
     }
 
     return render_to_response('django_js_reverse/urls_js.tpl',


### PR DESCRIPTION
Hi,

This fixes the content type of the jsreverse script. Right now, it's being sent as "mimetype"  or "content_type".
