### PR TITLE
Add template tag to inline js_reverse javascript.

### DIFF
--- a/django_js_reverse/templatetags/js_reverse.py
+++ b/django_js_reverse/templatetags/js_reverse.py
@@ -1,0 +1,18 @@
+from django import template
+
+from django_js_reverse.views import urls_js
+
+
+register = template.Library()
+
+
+@register.simple_tag(takes_context=True)
+def js_reverse_inline(context):
+    """
+    Outputs a string of javascript that can generate URLs via the use
+    of the names given to those URLs.
+    """
+    if 'request' in context:
+        return urls_js(context['request']).content
+    else:
+        return u''


### PR DESCRIPTION
Hello @ierror, I have had the need to inline the js from your package and I thought I might contribute back to your project. However, I wanted to check and see if you'd be interested in this addition before I put in the effort to build out tests and docs. Would you be interested in such a template tag as the one in this commit? Usage would be something like the following:

```
  {% load js_reverse %}

  <script type="text/javascript" charset="utf-8">
    {% js_reverse_inline %}
  </script>
```