### PR TITLE
Add support for nested namespaces, arguments within namespace paths, and optional arguments

### DIFF
--- a/django_js_reverse/templates/django_js_reverse/urls_js.tpl
+++ b/django_js_reverse/templates/django_js_reverse/urls_js.tpl
@@ -9,8 +9,13 @@ this.{{ js_var_name }} = (function () {
     Urls._get_url = function (url_pattern) {
         var self = this._instance
         return function () {
-            var index, url, url_arg, url_args, _i, _len, _ref;
-            _ref = self.url_patterns[url_pattern], url = _ref[0], url_args = _ref[1];
+            var index, url, url_arg, url_args, _i, _len, _ref, _ref_list;
+            _ref_list = self.url_patterns[url_pattern];
+            for (_i = 0;
+                 _ref = _ref_list[_i], _ref[1].length != arguments.length;
+                 _i++);
+
+            url = _ref[0], url_args = _ref[1];
             for (index = _i = 0, _len = url_args.length; _i < _len; index = ++_i) {
                 url_arg = url_args[index];
                 url = url.replace("%(" + url_arg + ")s", arguments[index] || '');
@@ -22,9 +27,21 @@ this.{{ js_var_name }} = (function () {
     Urls.init = function () {
         var name, pattern, self, url_patterns, _i, _len, _ref;
         url_patterns = [
-            {% for name, namespace_path, pattern in urls %}
+            {% for name, patterns in urls %}
                 [
-                    '{{name|escapejs}}', ['{{namespace_path}}{{pattern.0|escapejs}}', [{% for arg in pattern.1 %}'{{ arg|escapejs }}'{% if not forloop.last %},{% endif %}{% endfor %}]]
+                    '{{name|escapejs}}',
+                    [
+                        {% for path, args in patterns %}
+                        [
+                            '{{path|escapejs}}',
+                            [
+                                {% for arg in args %}
+                                '{{arg|escapejs}}',
+                                {% endfor %}
+                            ]{% if not forloop.last %},{% endif %}
+                        ]{% if not forloop.last %},{% endif %}
+                        {% endfor %}
+                    ]{% if not forloop.last %},{% endif %}
                 ]{% if not forloop.last %},{% endif %}
             {% endfor %}
         ];

--- a/django_js_reverse/tests/test_urls.py
+++ b/django_js_reverse/tests/test_urls.py
@@ -36,6 +36,10 @@ pattern_ns_1 = patterns('',
 pattern_ns_2 = patterns('',
                         url(r'', include(basic_patterns)))
 
+pattern_ns_arg = patterns('',
+                          url(r'', include(basic_patterns)))
+
 urlpatterns += patterns('',
                         url(r'^ns1/', include(pattern_ns_1, namespace='ns1')),
-                        url(r'^ns2/', include(pattern_ns_2, namespace='ns2')))
+                        url(r'^ns2/', include(pattern_ns_2, namespace='ns2')),
+                        url(r'^ns(?P<ns_arg>[^/]*)/', include(pattern_ns_arg, namespace='ns_arg')))

--- a/django_js_reverse/tests/test_urls.py
+++ b/django_js_reverse/tests/test_urls.py
@@ -24,6 +24,8 @@ basic_patterns = patterns('',
                               name='test_one_url_args'),
                           url(r'^test_two_url_args/(?P<arg_one>[-\w]+)-(?P<arg_two>[-\w]+)/$', 'foo',
                               name='test_two_url_args'),
+                          url(r'^test_optional_url_arg/(?:1_(?P<arg_one>[-\w]+)-)?2_(?P<arg_two>[-\w]+)/$', 'foo',
+                              name='test_optional_url_arg'),
                           url(r'^test_unicode_url_name/$', 'foo',
                               name=u('test_unicode_url_name')))
 

--- a/django_js_reverse/tests/unit_tests.py
+++ b/django_js_reverse/tests/unit_tests.py
@@ -56,6 +56,12 @@ class JSReverseViewTestCaseMinified(TestCase):
     def test_view_two_url_args(self):
         self.assertEqualJSUrlEval('Urls.test_two_url_args("arg_one", "arg_two")', '/test_two_url_args/arg_one-arg_two/')
 
+    def test_view_optional_url_arg(self):
+        self.assertEqualJSUrlEval('Urls.test_optional_url_arg("arg_two")',
+                                  '/test_optional_url_arg/2_arg_two/')
+        self.assertEqualJSUrlEval('Urls.test_optional_url_arg("arg_one", "arg_two")',
+                                  '/test_optional_url_arg/1_arg_one-2_arg_two/')
+
     def test_unicode_url_name(self):
         self.assertEqualJSUrlEval('Urls.test_unicode_url_name()', '/test_unicode_url_name/')
 

--- a/django_js_reverse/tests/unit_tests.py
+++ b/django_js_reverse/tests/unit_tests.py
@@ -75,6 +75,8 @@ class JSReverseViewTestCaseMinified(TestCase):
                                   '/ns1/test_two_url_args/arg_one-arg_two/')
         self.assertEqualJSUrlEval('Urls["ns2:test_two_url_args"]("arg_one", "arg_two")',
                                   '/ns2/test_two_url_args/arg_one-arg_two/')
+        self.assertEqualJSUrlEval('Urls["ns_arg:test_two_url_args"]("arg_one", "arg_two", "arg_three")',
+                                  '/nsarg_one/test_two_url_args/arg_two-arg_three/')
 
     def test_content_type(self):
         response = self.client.post('/jsreverse/')

--- a/django_js_reverse/views.py
+++ b/django_js_reverse/views.py
@@ -37,20 +37,10 @@ def urls_js(request):
 
     default_urlresolver = urlresolvers.get_resolver(None)
 
-    # prepare data for namespeced urls
-    named_urlresolves = [
-        (n_urlresolver, namespace_path, namespace + ':')
-        for namespace, (namespace_path, n_urlresolver) in default_urlresolver.namespace_dict.items()
-    ]
-    url_lists = [prepare_url_list(*args) for args in named_urlresolves]
-
-    # add urls without namespaces
-    url_lists.append((prepare_url_list(default_urlresolver)))
-
     response_body = loader.render_to_string(
         'django_js_reverse/urls_js.tpl',
         {
-            'urls': chain(*url_lists),
+            'urls': list(prepare_url_list(default_urlresolver)),
             'url_prefix': urlresolvers.get_script_prefix(),
             'js_var_name': js_var_name
         },
@@ -64,8 +54,13 @@ def prepare_url_list(urlresolver, namespace_path='', namespace=''):
     """
     returns list of tuples [(<url_name>, <namespace_path>, <url_patern_tuple> ), ...]
     """
-    prepared_list = []
     for url_name, url_pattern in urlresolver.reverse_dict.items():
-        if isinstance(url_name, text_type) or isinstance(url_name, str):
-            prepared_list.append([namespace + url_name, namespace_path, url_pattern[0][0]])
-    return prepared_list
+        if isinstance(url_name, (text_type, str)):
+            yield [namespace + url_name, namespace_path, url_pattern[0][0]]
+
+    for inner_ns, (inner_ns_path, inner_urlresolver) in \
+            urlresolver.namespace_dict.items():
+        for x in prepare_url_list(inner_urlresolver,
+                                  namespace_path + inner_ns_path,
+                                  namespace + inner_ns + ':'):
+            yield x

--- a/django_js_reverse/views.py
+++ b/django_js_reverse/views.py
@@ -60,7 +60,15 @@ def prepare_url_list(urlresolver, namespace_path='', namespace=''):
 
     for inner_ns, (inner_ns_path, inner_urlresolver) in \
             urlresolver.namespace_dict.items():
-        for x in prepare_url_list(inner_urlresolver,
-                                  namespace_path + inner_ns_path,
-                                  namespace + inner_ns + ':'):
+        inner_ns_path = namespace_path + inner_ns_path
+        inner_ns = namespace + inner_ns + ':'
+
+        # if we have inner_ns_path, reconstruct a new resolver so that we can
+        # handle regex substitutions within the regex of a namespace.
+        if inner_ns_path:
+            inner_urlresolver = urlresolvers.get_ns_resolver(inner_ns_path,
+                                                             inner_urlresolver)
+            inner_ns_path = ''
+
+        for x in prepare_url_list(inner_urlresolver, inner_ns_path, inner_ns):
             yield x

--- a/django_js_reverse/views.py
+++ b/django_js_reverse/views.py
@@ -52,11 +52,14 @@ def urls_js(request):
 
 def prepare_url_list(urlresolver, namespace_path='', namespace=''):
     """
-    returns list of tuples [(<url_name>, <namespace_path>, <url_patern_tuple> ), ...]
+    returns list of tuples [(<url_name>, <url_patern_tuple> ), ...]
     """
     for url_name, url_pattern in urlresolver.reverse_dict.items():
         if isinstance(url_name, (text_type, str)):
-            yield [namespace + url_name, namespace_path, url_pattern[0][0]]
+            yield [
+                namespace + url_name,
+                [[namespace_path + pat[0], pat[1]] for pat in url_pattern[0]]
+             ]
 
     for inner_ns, (inner_ns_path, inner_urlresolver) in \
             urlresolver.namespace_dict.items():


### PR DESCRIPTION
These series of commits add support for handling nested namespaces (e.g. `'foo:bar:baz:pattern_name'`), arguments within namespace paths (e.g. `url(r'^ns(?P<ns_arg>[^/]*)/', include(pattern_ns_arg, namespace='ns_arg')))`), and optional arguments (e.g. `r'(?:(?P<arg>.*))?'`).