### PR TITLE
Clean up javascript

### DIFF
--- a/django_js_reverse/management/commands/collectstatic_js_reverse.py
+++ b/django_js_reverse/management/commands/collectstatic_js_reverse.py
@@ -3,6 +3,7 @@ import sys
 from os.path import join, dirname
 from django.core.management.base import BaseCommand
 
+import django_js_reverse
 from django.core.files.storage import FileSystemStorage
 from django.core.files.base import ContentFile
 from django_js_reverse.views import urls_js
@@ -12,7 +13,7 @@ class Command(BaseCommand):
     help = 'Creates a static urls-js file for django-js-reverse'
 
     def handle(self, *args, **options):
-            package_path = dirname(__file__)
+            package_path = dirname(django_js_reverse.__file__)
             location = join(package_path, 'static', 'django_js_reverse', 'js')
             file = 'reverse.js'
             fs = FileSystemStorage(location=location)

--- a/django_js_reverse/templates/django_js_reverse/urls_js.tpl
+++ b/django_js_reverse/templates/django_js_reverse/urls_js.tpl
@@ -23,34 +23,32 @@ this.{{ js_var_name }} = (function () {
         };
     };
 
-    (function(self) {
-        var name, pattern, self, url_patterns, _i, _len, _ref;
-        url_patterns = [
-            {% for name, patterns in urls %}
+    var name, pattern, self, url_patterns, _i, _len, _ref;
+    url_patterns = [
+        {% for name, patterns in urls %}
+            [
+                '{{name|escapejs}}',
                 [
-                    '{{name|escapejs}}',
+                    {% for path, args in patterns %}
                     [
-                        {% for path, args in patterns %}
+                        '{{path|escapejs}}',
                         [
-                            '{{path|escapejs}}',
-                            [
-                                {% for arg in args %}
-                                '{{arg|escapejs}}',
-                                {% endfor %}
-                            ]{% if not forloop.last %},{% endif %}
+                            {% for arg in args %}
+                            '{{arg|escapejs}}',
+                            {% endfor %}
                         ]{% if not forloop.last %},{% endif %}
-                        {% endfor %}
                     ]{% if not forloop.last %},{% endif %}
+                    {% endfor %}
                 ]{% if not forloop.last %},{% endif %}
-            {% endfor %}
-        ];
-        self.url_patterns = {};
-        for (_i = 0, _len = url_patterns.length; _i < _len; _i++) {
-            _ref = url_patterns[_i], name = _ref[0], pattern = _ref[1];
-            self.url_patterns[name] = pattern;
-            Urls[name] = _get_url(name);
-        }
-    })(self);
+            ]{% if not forloop.last %},{% endif %}
+        {% endfor %}
+    ];
+    self.url_patterns = {};
+    for (_i = 0, _len = url_patterns.length; _i < _len; _i++) {
+        _ref = url_patterns[_i], name = _ref[0], pattern = _ref[1];
+        self.url_patterns[name] = pattern;
+        Urls[name] = _get_url(name);
+    }
 
     return Urls;
 })();

--- a/django_js_reverse/templates/django_js_reverse/urls_js.tpl
+++ b/django_js_reverse/templates/django_js_reverse/urls_js.tpl
@@ -48,6 +48,7 @@ this.{{ js_var_name }} = (function () {
         _ref = url_patterns[_i], name = _ref[0], pattern = _ref[1];
         self.url_patterns[name] = pattern;
         Urls[name] = _get_url(name);
+        Urls[name.replace('-', '_')] = _get_url(name);
     }
 
     return Urls;

--- a/django_js_reverse/templates/django_js_reverse/urls_js.tpl
+++ b/django_js_reverse/templates/django_js_reverse/urls_js.tpl
@@ -1,13 +1,12 @@
 this.{{ js_var_name }} = (function () {
 
-    function Urls() {}
+    var Urls = {};
 
-    Urls._instance = {
+    var self = {
         url_patterns:{}
     };
 
-    Urls._get_url = function (url_pattern) {
-        var self = this._instance
+    _get_url = function (url_pattern) {
         return function () {
             var index, url, url_arg, url_args, _i, _len, _ref, _ref_list;
             _ref_list = self.url_patterns[url_pattern];
@@ -24,7 +23,7 @@ this.{{ js_var_name }} = (function () {
         };
     };
 
-    Urls.init = function () {
+    (function(self) {
         var name, pattern, self, url_patterns, _i, _len, _ref;
         url_patterns = [
             {% for name, patterns in urls %}
@@ -45,19 +44,13 @@ this.{{ js_var_name }} = (function () {
                 ]{% if not forloop.last %},{% endif %}
             {% endfor %}
         ];
-        self = this._instance;
         self.url_patterns = {};
         for (_i = 0, _len = url_patterns.length; _i < _len; _i++) {
             _ref = url_patterns[_i], name = _ref[0], pattern = _ref[1];
             self.url_patterns[name] = pattern;
-            this[name] = this._get_url(name);
+            Urls[name] = _get_url(name);
         }
-        return self;
-    };
+    })(self);
 
     return Urls;
 })();
-
-this.{{ js_var_name }}.init();
-
-

--- a/django_js_reverse/templates/django_js_reverse/urls_js.tpl
+++ b/django_js_reverse/templates/django_js_reverse/urls_js.tpl
@@ -48,7 +48,7 @@ this.{{ js_var_name }} = (function () {
         _ref = url_patterns[_i], name = _ref[0], pattern = _ref[1];
         self.url_patterns[name] = pattern;
         Urls[name] = _get_url(name);
-        Urls[name.replace('-', '_')] = _get_url(name);
+        Urls[name.replace(/-/g, '_')] = _get_url(name);
     }
 
     return Urls;

--- a/django_js_reverse/tests/unit_tests.py
+++ b/django_js_reverse/tests/unit_tests.py
@@ -115,7 +115,7 @@ class JSReverseViewTestCaseNotMinified(JSReverseViewTestCaseMinified):
 
 
 class JSReverseStaticFileSaveTest(JSReverseViewTestCaseMinified):
-    def _test_reverse_js_file_save(self):
+    def test_reverse_js_file_save(self):
         call_command('collectstatic_js_reverse')
 
         package_path = dirname(django_js_reverse.__file__)


### PR DESCRIPTION
I removed the unnecessary `this` and `init` function.
Django rest framework generates url names like `user-list`, so it get's converted now as well so `Urls['user-list']()` or the cleaner `Urls.user_list()` are both usable.