### PR TITLE
Remove request argument for urls_js function in js_reverse_inline

### DIFF
--- a/django_js_reverse/templatetags/js_reverse.py
+++ b/django_js_reverse/templatetags/js_reverse.py
@@ -6,10 +6,10 @@ from django_js_reverse.views import urls_js
 register = template.Library()
 
 
-@register.simple_tag(takes_context=True)
-def js_reverse_inline(context):
+@register.simple_tag()
+def js_reverse_inline():
     """
     Outputs a string of javascript that can generate URLs via the use
     of the names given to those URLs.
     """
-    return urls_js(context.get('request'))
+    return urls_js()

--- a/django_js_reverse/templatetags/js_reverse.py
+++ b/django_js_reverse/templatetags/js_reverse.py
@@ -6,8 +6,8 @@ from django_js_reverse.views import urls_js
 register = template.Library()
 
 
-@register.simple_tag()
-def js_reverse_inline():
+@register.simple_tag(takes_context=True)
+def js_reverse_inline(context):
     """
     Outputs a string of javascript that can generate URLs via the use
     of the names given to those URLs.


### PR DESCRIPTION
Tag returns HttpResponse to template with 'request' argument.