### PR TITLE
Add support for duplicate URL names

### DIFF
--- a/django_js_reverse/tests/test_urls.py
+++ b/django_js_reverse/tests/test_urls.py
@@ -12,7 +12,7 @@ if sys.version < '3':
 else:
     def u(x):
         return x
-    
+
 
 def dummy_view(*args, **kwargs):
     pass
@@ -30,7 +30,11 @@ basic_patterns = patterns('',
                           url(r'^test_optional_url_arg/(?:1_(?P<arg_one>[-\w]+)-)?2_(?P<arg_two>[-\w]+)/$', dummy_view,
                               name='test_optional_url_arg'),
                           url(r'^test_unicode_url_name/$', dummy_view,
-                              name=u('test_unicode_url_name')))
+                              name=u('test_unicode_url_name')),
+                          url(r'^test_duplicate_name/(?P<arg_one>[-\w]+)/$', dummy_view,
+                              name='test_duplicate_name'),
+                          url(r'^test_duplicate_name/(?P<arg_one>[-\w]+)-(?P<arg_two>[-\w]+)/$', dummy_view,
+                              name='test_duplicate_name'))
 
 urlpatterns = copy(basic_patterns)
 

--- a/django_js_reverse/tests/unit_tests.py
+++ b/django_js_reverse/tests/unit_tests.py
@@ -112,6 +112,12 @@ class JSReverseViewTestCaseMinified(AbstractJSReverseTestCase, TestCase):
         response = self.client.get('/jsreverse/')
         self.assertNotContains(response, 'exclude_namespace', status_code=200)
 
+    def test_duplicate_name(self):
+        self.assertEqualJSUrlEval('Urls.test_duplicate_name("arg_one")',
+                                  '/test_duplicate_name/arg_one/')
+        self.assertEqualJSUrlEval('Urls.test_duplicate_name("arg_one", "arg_two")',
+                                  '/test_duplicate_name/arg_one-arg_two/')
+
 
 @override_settings(JS_REVERSE_JS_MINIFY=False)
 class JSReverseViewTestCaseNotMinified(JSReverseViewTestCaseMinified):

--- a/django_js_reverse/views.py
+++ b/django_js_reverse/views.py
@@ -71,12 +71,14 @@ def prepare_url_list(urlresolver, namespace_path='', namespace=''):
     if namespace[:-1] in exclude_ns:
         return
 
-    for url_name, url_pattern in urlresolver.reverse_dict.items():
+    for url_name in urlresolver.reverse_dict.keys():
         if isinstance(url_name, (text_type, str)):
-            yield [
-                namespace + url_name,
-                [[namespace_path + pat[0], pat[1]] for pat in url_pattern[0]]
-            ]
+            url_patterns = []
+            for url_pattern in urlresolver.reverse_dict.getlist(url_name):
+                url_patterns += [
+                    [namespace_path + pat[0], pat[1]] for pat in url_pattern[0]
+                ]
+            yield [namespace + url_name, url_patterns]
 
     for inner_ns, (inner_ns_path, inner_urlresolver) in \
             urlresolver.namespace_dict.items():


### PR DESCRIPTION
Django allows you to have multiple URL patterns with the same name. This PR adds support for the featuer to `django-js-reverse` bringing it more in-line with Djanto's `reverse`.