### PR TITLE
Keyword-based URL reversing

### DIFF
--- a/django_js_reverse/templates/django_js_reverse/urls_js.tpl
+++ b/django_js_reverse/templates/django_js_reverse/urls_js.tpl
@@ -11,7 +11,8 @@
             var index, url, url_arg, url_args, _i, _len, _ref, _ref_list;
             _ref_list = self.url_patterns[url_pattern];
             for (_i = 0;
-                 _ref = _ref_list[_i], _ref[1].length != arguments.length;
+                 _i < _ref_list.length &&
+                 (_ref = _ref_list[_i], _ref[1].length != arguments.length);
                  _i++);
 
             url = _ref[0], url_args = _ref[1];

--- a/django_js_reverse/templates/django_js_reverse/urls_js.tpl
+++ b/django_js_reverse/templates/django_js_reverse/urls_js.tpl
@@ -16,18 +16,21 @@
 
             if (arguments.length == 1 && typeof (arguments[0]) == "object") {
                 // kwargs mode
-                provided_keys = new Set (Object.keys (arguments[0]));
+                var provided_keys_list = Object.keys (arguments[0]);
+                provided_keys = {};
+                for (_i = 0; _i < provided_keys_list.length; _i++)
+                    provided_keys[provided_keys_list[_i]] = 1;
 
                 match_ref = function (ref)
                 {
                     var _i;
 
                     // Verify that they have the same number of arguments
-                    if (ref[1].length != provided_keys.size)
+                    if (ref[1].length != provided_keys_list.length)
                         return false;
 
                     for (_i = 0;
-                         _i < ref[1].length && provided_keys.has (ref[1][_i]);
+                         _i < ref[1].length && ref[1][_i] in provided_keys;
                          _i++);
 
                     // If for loop completed, we have all keys

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -34,7 +34,10 @@ basic_patterns = patterns('',
                           url(r'^test_duplicate_name/(?P<arg_one>[-\w]+)/$', dummy_view,
                               name='test_duplicate_name'),
                           url(r'^test_duplicate_name/(?P<arg_one>[-\w]+)-(?P<arg_two>[-\w]+)/$', dummy_view,
-                              name='test_duplicate_name'))
+                              name='test_duplicate_name'),
+                          url(r'^test_duplicate_argcount/(?P<arg_one>[-\w]+)?-(?P<arg_two>[-\w]+)?/$', dummy_view,
+                              name='test_duplicate_argcount'),
+                      )
 
 urlpatterns = copy(basic_patterns)
 

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -119,12 +119,20 @@ class JSReverseViewTestCaseMinified(AbstractJSReverseTestCase, TestCase):
         with script_prefix('/foobarlala/'):
             self.assertEqualJSUrlEval('Urls["nestedns:ns1:test_two_url_args"]("arg_one", "arg_two")',
                                       '/foobarlala/nestedns/ns1/test_two_url_args/arg_one-arg_two/')
-    
+
     def test_duplicate_name(self):
         self.assertEqualJSUrlEval('Urls.test_duplicate_name("arg_one")',
                                   '/test_duplicate_name/arg_one/')
         self.assertEqualJSUrlEval('Urls.test_duplicate_name("arg_one", "arg_two")',
                                   '/test_duplicate_name/arg_one-arg_two/')
+
+    def test_duplicate_argcount(self):
+        self.assertEqualJSUrlEval('Urls.test_duplicate_argcount ({arg_one: "arg_one"})',
+                                  '/test_duplicate_argcount/arg_one-/')
+        self.assertEqualJSUrlEval('Urls.test_duplicate_argcount ({arg_two: "arg_two"})',
+                                  '/test_duplicate_argcount/-arg_two/')
+        self.assertEqualJSUrlEval('Urls.test_duplicate_argcount ({arg_one: "arg_one", arg_two: "arg_two"})',
+                                  '/test_duplicate_argcount/arg_one-arg_two/')
 
 
 @override_settings(JS_REVERSE_JS_MINIFY=False)


### PR DESCRIPTION
These bunch of commits introduce keyword-based URL reversing, complete with a testcase. This is useful in cases where there are multiple optional arguments that can result in some ambiguity in which argument goes where.