### PR TITLE
urls_js should not return HttpResponse

### DIFF
--- a/django_js_reverse/views.py
+++ b/django_js_reverse/views.py
@@ -56,10 +56,7 @@ def urls_js(request=None):
     if minfiy:
         response_body = minify(response_body, mangle=True, mangle_toplevel=False)
 
-    if not request:
-        return response_body
-    else:
-        return HttpResponse(response_body, **{'content_type': 'application/javascript'})
+    return response_body
 
 
 def prepare_url_list(urlresolver, namespace_path='', namespace=''):


### PR DESCRIPTION
From what I can tell, urls_js is supposed to return pure javascript text. But when passed a request object, it returns that text wrapped in an HttpResponse, which unnecessarily adds "Content-type: application/javascript" at the beginning of the output. This breaks the `js_reverse_inline` template tag, because "Content-type: application/javascript" is not valid javascript code.

This plugin is super awesome, so I hope you can incorporate this fix and get it pushed out to PyPI asap, so others won't run into the same problem that I did.