### PR TITLE
Fix: collectstatic_js_reverse usage message

### DIFF
--- a/django_js_reverse/management/commands/collectstatic_js_reverse.py
+++ b/django_js_reverse/management/commands/collectstatic_js_reverse.py
@@ -21,7 +21,7 @@ class Command(BaseCommand):
             return output_path
 
         if not hasattr(settings, 'STATIC_ROOT') or not settings.STATIC_ROOT:
-            raise ImproperlyConfigured('The collectstatic_js_reverse command needs settings.JS_OUTPUT_PATH or settings.STATIC_ROOT to be set.')
+            raise ImproperlyConfigured('The collectstatic_js_reverse command needs settings.JS_REVERSE_OUTPUT_PATH or settings.STATIC_ROOT to be set.')
 
         return os.path.join(settings.STATIC_ROOT, 'django_js_reverse', 'js')
 


### PR DESCRIPTION
should refer to JS_REVERSE_OUTPUT_PATH instead of JS_OUTPUT_PATH.