### PR TITLE
Add ES6 Module formatting option

### DIFF
--- a/django_js_reverse/core.py
+++ b/django_js_reverse/core.py
@@ -112,7 +112,10 @@ def generate_js(default_urlresolver):
     else:
         script_prefix = urlresolvers.get_script_prefix()
 
+    es6_module = getattr(settings, 'JS_REVERSE_ES6_MODULE', False)
+
     js_content = loader.render_to_string('django_js_reverse/urls_js.tpl', {
+        'es6_module': es6_module,
         'urls': sorted(list(prepare_url_list(default_urlresolver))),
         'url_prefix': script_prefix,
         'js_var_name': js_var_name,

--- a/django_js_reverse/templates/django_js_reverse/urls_js.tpl
+++ b/django_js_reverse/templates/django_js_reverse/urls_js.tpl
@@ -1,6 +1,6 @@
 {% if es6_module %}
     const reverse =
-{% else % }
+{% else %}
     {{ js_global_object_name }}.{{ js_var_name }} =
 {% endif %}
 (function () {

--- a/django_js_reverse/templates/django_js_reverse/urls_js.tpl
+++ b/django_js_reverse/templates/django_js_reverse/urls_js.tpl
@@ -1,4 +1,9 @@
-{{ js_global_object_name }}.{{ js_var_name }} = (function () {
+{% if es6_module %}
+    const reverse =
+{% else % }
+    {{ js_global_object_name }}.{{ js_var_name }} =
+{% endif %}
+(function () {
 
     var Urls = {};
 
@@ -110,3 +115,6 @@
 
     return Urls;
 })();
+{% if es6_module %}
+    export default reverse
+{% endif %}


### PR DESCRIPTION
This add an additional configuration option to format the JS file as an ES6 module. It's useful if the JS in your Django app is all configured around ES6 modules, and is a fairly simple addition to the template.

To use, you would do the follow in your application JS module:
```
import reverse from "./reverse.js";  // Pointing to wherever you output the reverse.js file
reverse['login']();
```