### PR TITLE
Change False to 'window' in global object name in README.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -203,7 +203,7 @@ used to access the named urls is attached to. Default is :code:`this`
 
 ::
 
-    JS_REVERSE_JS_GLOBAL_OBJECT_NAME = False
+    JS_REVERSE_JS_GLOBAL_OBJECT_NAME = 'window'
 
 
 Optionally, you can disable the minfication of the generated javascript file


### PR DESCRIPTION
False doesn't work for the JS_REVERSE_JS_GLOBAL_OBJECT_NAME settings - the code expects it to be a string. I presume some people will want to attach this globally, so 'window' makes sense.