### PR TITLE
Update test matrix to add Django 1.11 and remove python 2.6

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,9 @@
 [tox]
 envlist =
-    py26-django{1.6,1.5},
-    py27-django{1.10,1.9,1.8,1.7,1.6,1.5},
+    py27-django{1.11,1.10,1.9,1.8,1.7,1.6,1.5},
     py33-django{1.8,1.7,1.6,1.5},
-    py34-django{1.10,1.9,1.8,1.7,1.6,1.5},
-    py35-django{1.10,1.9,1.8},
+    py34-django{1.11,1.10,1.9,1.8,1.7,1.6,1.5},
+    py35-django{1.11,1.10,1.9,1.8},
 
 [testenv]
 usedevelop = true
@@ -19,3 +18,4 @@ deps=
     django1.8: Django>=1.8,<1.9
     django1.9: Django>=1.9,<1.10
     django1.10: Django>=1.10,<1.11
+    django1.11: Django>=1.11,<1.12


### PR DESCRIPTION
Travis builds for Django 1.5 and 1.6 under Python 2.6 failed.

$ tox
py26-django1.6 create: /home/travis/build/ierror/django-js-reverse/.tox/py26-django1.6
ERROR: InterpreterNotFound: python2.6
py26-django1.5 create: /home/travis/build/ierror/django-js-reverse/.tox/py26-django1.5
ERROR: InterpreterNotFound: python2.6