### PR TITLE
Now using LooseVersion instead of StrictVersion to avoid issues with rc releases

### DIFF
--- a/django_js_reverse/core.py
+++ b/django_js_reverse/core.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import re
 import sys
-from distutils.version import StrictVersion
+from distutils.version import LooseVersion
 
 import django
 from django.conf import settings
@@ -88,7 +88,7 @@ def prepare_url_list(urlresolver, namespace_path='', namespace=''):
             args = [inner_ns_path, inner_urlresolver]
 
             # https://github.com/ierror/django-js-reverse/issues/65
-            if StrictVersion(django.get_version()) >= StrictVersion("2.0.6"):
+            if LooseVersion(django.get_version()) >= LooseVersion("2.0.6"):
                 args.append(tuple(urlresolver.pattern.converters.items()))
 
             inner_urlresolver = urlresolvers.get_ns_resolver(*args)


### PR DESCRIPTION
So it turns out ``distutils.version.StrictVersion`` doesn't actually follow [PEP 440](https://www.python.org/dev/peps/pep-0440/#public-version-identifiers). Awesome.

Switching to ``LooseVersion``, as ``StrictVersion`` raises a ValueError when it thinks it's given an invalid version number (e.g. "2.1rc1")