### PR TITLE
test on js2py an ES5 impl

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ pip_pre = true
 commands = coverage run -p django_js_reverse/tests/unit_tests.py
 deps=
     coverage==4.5.1
+    js2py==0.63
     django15: Django>=1.5,<1.6
     django16: Django>=1.6,<1.7
     django17: Django>=1.7,<1.8


### PR DESCRIPTION
when switching from Phantom to node - we lost any tests that make sure
the code works on IE11 at all. Eg. someone could introduce arrow
functions or let/const and it would pass the tests.

Here js2py is an ES5 impl that's also easy to run from Python.