### PR TITLE
Add a bare-bones index.rst to fix readthedocs build

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -1,0 +1,8 @@
+.. include:: ./README.rst
+
+==========
+Change Log
+==========
+
+.. include:: ./CHANGELOG.rst
+


### PR DESCRIPTION
I presume either readthedocs or sphinx used to look for README.rst (3 years ago heh), and doesn't any more.  Resolved by adding in a bare-bones index.rst.

Resolves #82

Also:

* Check if the github webhooks are still working, since I notice you merged a PR yesterday and it doesn't seem to have caused a (failed) readthedocs build?
* I suggest changing the python interpreter in the readthedocs config to 3.x.
