### PR TITLE
docs: Fix simple typo, varible -> variable

### DIFF
--- a/django_js_reverse/core.py
+++ b/django_js_reverse/core.py
@@ -43,7 +43,7 @@ def prepare_url_list(urlresolver, namespace_path='', namespace=''):
     if namespace[:-1] in exclude_ns:
         return
 
-    include_only_allow = True  # include_only state varible
+    include_only_allow = True  # include_only state variable
 
     if include_only_ns != []:
         # True mean that ns passed the test


### PR DESCRIPTION
There is a small typo in django_js_reverse/core.py.

Should read `variable` rather than `varible`.

