### PR TITLE
Replaced force_text() with force_str(), since its deprecated in Django 3.0.

### DIFF
--- a/django_js_reverse/core.py
+++ b/django_js_reverse/core.py
@@ -10,7 +10,11 @@ from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.template import loader
 from django.utils.safestring import mark_safe
-from django.utils.encoding import force_str
+
+if sys.version_info <= (2, 7):
+    from django.utils.encoding import force_text
+else:
+    from django.utils.encoding import force_str as force_text
 
 from . import rjsmin
 from .js_reverse_settings import (JS_EXCLUDE_NAMESPACES, JS_GLOBAL_OBJECT_NAME,
@@ -112,9 +116,9 @@ def generate_json(default_urlresolver, script_prefix=None):
     return collections.OrderedDict([
         ('urls', [
             [
-                force_str(name),
+                force_text(name),
                 [
-                    [force_str(path), [force_str(arg) for arg in args]]
+                    [force_text(path), [force_text(arg) for arg in args]]
                     for path, args in patterns
                 ],
             ] for name, patterns in urls

--- a/django_js_reverse/core.py
+++ b/django_js_reverse/core.py
@@ -110,9 +110,9 @@ def generate_json(default_urlresolver, script_prefix=None):
     return {
         'urls': [
             [
-                force_text(name),
+                force_str(name),
                 [
-                    [force_text(path), [force_text(arg) for arg in args]]
+                    [force_str(path), [force_str(arg) for arg in args]]
                     for path, args in patterns
                 ],
             ] for name, patterns in urls

--- a/django_js_reverse/core.py
+++ b/django_js_reverse/core.py
@@ -11,7 +11,7 @@ from django.core.exceptions import ImproperlyConfigured
 from django.template import loader
 from django.utils.safestring import mark_safe
 
-if sys.version_info <= (2, 7):
+if sys.version_info < (3, ):
     from django.utils.encoding import force_text
 else:
     from django.utils.encoding import force_str as force_text

--- a/django_js_reverse/core.py
+++ b/django_js_reverse/core.py
@@ -9,7 +9,7 @@ from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.template import loader
 from django.utils.safestring import mark_safe
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 
 from . import rjsmin
 from .js_reverse_settings import (JS_EXCLUDE_NAMESPACES, JS_GLOBAL_OBJECT_NAME,


### PR DESCRIPTION
I've checked, and I'm sure that this code will work in Django 3.0 and Django 2.x. `force_str()` is just an alias of `force_text()` back to Django 2.0.

This code will _run_ in Django 1.11 (the earliest version that django-js-reverse supports), but I don't know for sure that it'll actually do the right thing. Back then, `force_str()` was an alias for `force_bytes()` in Python 2.x, while being an alias for `force_text()` in Python 3.x. So folks still using Django 1.11 in Python 2.7 _might_ see different behavior. However, since django-js-reverse only uses `force_str()` to build a dictionary for export as JSON, I don't think this'll be an issue.