### PR TITLE
docs: Fix a few typos

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -233,7 +233,7 @@ notation instead:
     Urls['betterliving-get-house']('house', 12)
     Urls['namespace:betterliving-get-house']('house', 12)
 
-You can also pass javascript objects to match keyword aguments like the
+You can also pass javascript objects to match keyword arguments like the
 examples bellow:
 
 ::
@@ -259,7 +259,7 @@ used to access the named urls is attached to. Default is :code:`this`
     JS_REVERSE_JS_GLOBAL_OBJECT_NAME = 'window'
 
 
-Optionally, you can disable the minfication of the generated javascript file
+Optionally, you can disable the minification of the generated javascript file
 by django setting
 
 ::
@@ -282,7 +282,7 @@ To exclude any namespaces from the generated javascript file, add them to the `J
 If you want to include only specific namespaces add them to the `JS_REVERSE_INCLUDE_ONLY_NAMESPACES` setting
 tips:
 * Use "" (empty string) for urls without namespace
-* Use "foo\0" to include urls just from "foo" namaspace and not from any subnamespaces (e.g. "foo:bar")
+* Use "foo\0" to include urls just from "foo" namespace and not from any subnamespaces (e.g. "foo:bar")
 
 ::
 

--- a/django_js_reverse/core.py
+++ b/django_js_reverse/core.py
@@ -36,7 +36,7 @@ JS_IDENTIFIER_RE = re.compile(r'^[$A-Z_][\dA-Z_$]*$')
 
 def prepare_url_list(urlresolver, namespace_path='', namespace=''):
     """
-    returns list of tuples [(<url_name>, <url_patern_tuple> ), ...]
+    returns list of tuples [(<url_name>, <url_pattern_tuple> ), ...]
     """
     exclude_ns = getattr(settings, 'JS_REVERSE_EXCLUDE_NAMESPACES', JS_EXCLUDE_NAMESPACES)
     include_only_ns = getattr(settings, 'JS_REVERSE_INCLUDE_ONLY_NAMESPACES', JS_INCLUDE_ONLY_NAMESPACES)
@@ -110,7 +110,7 @@ def generate_json(default_urlresolver, script_prefix=None):
     if script_prefix is None:
         script_prefix = urlresolvers.get_script_prefix()
 
-    # Ensure consistent ouptut ordering
+    # Ensure consistent output ordering
     urls = sorted(list(prepare_url_list(default_urlresolver)))
 
     return collections.OrderedDict([


### PR DESCRIPTION
There are small typos in:
- README.rst
- django_js_reverse/core.py

Fixes:
- Should read `pattern` rather than `patern`.
- Should read `output` rather than `ouptut`.
- Should read `namespace` rather than `namaspace`.
- Should read `minification` rather than `minfication`.
- Should read `arguments` rather than `aguments`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md